### PR TITLE
Return :wordchar mode after tag appears

### DIFF
--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -267,6 +267,7 @@ module HTMLDiff
             current_word << (use_brackets ? ']' : '>')
             words << current_word
             current_word = ''
+            mode = :wordchar
           else
             current_word << char
           end


### PR DESCRIPTION
This change helps to fix a bug related to incorrect display of audit trials ([here is the ticket](https://tablecheck.atlassian.net/browse/ROPE-1150))
The thing is that when we have a multi-line `reservation#memo`, when changing 1 line - everything is displayed correctly, but when changing 2 and subsequent lines - the changes are displayed incorrectly
This is due to the fact that after the first line a tag opens, which changes the mode to `:tag `and then, when we check subsequent lines - the mode does not change and we constantly go to the same tag case, instead of the `:wordchar` case
Therefore, the solution is to return the `:wordchar` tag after each closing bracket